### PR TITLE
Modify qcdb molecule to provide symmetry functions for pyoptking

### DIFF
--- a/psi4/driver/qcdb/libmintsmolecule.py
+++ b/psi4/driver/qcdb/libmintsmolecule.py
@@ -3050,6 +3050,9 @@ class LibmintsMolecule(object):
                     return False
         return True
 
+    # provide a more transparent name for this utility
+    is_symmetric = valid_atom_map
+
     #def valid_atom_map(self, tol=0.01):
     #    """Check if current geometry fits current point group
 

--- a/psi4/driver/qcdb/libmintsmolecule.py
+++ b/psi4/driver/qcdb/libmintsmolecule.py
@@ -3053,6 +3053,13 @@ class LibmintsMolecule(object):
     # provide a more transparent name for this utility
     is_symmetric = valid_atom_map
 
+    # Test a set of xyz coordinates to see if they satisfy the symmetry operations
+    # of the current molecule.
+    def is_XYZ_symmetric(self, XYZ, tol=0.01):
+        testmol = self.clone()
+        testmol.set_geometry(XYZ)
+        return testmol.is_symmetric(tol)
+
     #def valid_atom_map(self, tol=0.01):
     #    """Check if current geometry fits current point group
 

--- a/psi4/driver/qcdb/libmintsmolecule.py
+++ b/psi4/driver/qcdb/libmintsmolecule.py
@@ -2984,9 +2984,10 @@ class LibmintsMolecule(object):
         """
         return self.PYsymmetry_from_input
 
-    def symmetrize(self):
+    def symmetrize(self, tol=None):
         """Force the molecule to have the symmetry specified in pg.
-        This is to handle noise coming in from optking.
+        This is to handle noise coming in from optking.  Exception is thrown if
+        atoms cannot be mapped within tol(erance).
 
         """
         #raise FeatureNotImplemented('Molecule::symmetrize')  # FINAL SYMM
@@ -2994,7 +2995,11 @@ class LibmintsMolecule(object):
         ct = self.point_group().char_table()
 
         # Obtain atom mapping of atom * symm op to atom
-        atom_map = compute_atom_map(self)
+        # Allow compute_atom_map() to use its own default, if not specified here.
+        if tol is not None:
+            atom_map = compute_atom_map(self, tol)
+        else:
+            atom_map = compute_atom_map(self)
 
         # Symmetrize the molecule to remove any noise
         for at in range(self.natom()):
@@ -3248,7 +3253,7 @@ def equal_but_for_row_order(mat, rhs, tol=DEFAULT_SYM_TOL):
         return True
 
 
-def compute_atom_map(mol):
+def compute_atom_map(mol, tol=0.05):
     """Computes atom mappings during symmetry operations. Useful in
     generating SO information and Cartesian displacement SALCs.
     param mol Molecule to form mapping matrix from.
@@ -3281,7 +3286,7 @@ def compute_atom_map(mol):
                 for jj in range(3):
                     np3[ii] += so[ii][jj] * ac[jj]
 
-            atom_map[i][g] = mol.atom_at_position(np3, 0.05)
+            atom_map[i][g] = mol.atom_at_position(np3, tol)
             if atom_map[i][g] < 0:
                 print("""  Molecule:\n""")
                 mol.print_out()


### PR DESCRIPTION
## Description
Provide functions for pyOptking to check/enforce symmetry.
1. Provide is_symmetric(), just an alias to valid_atom_map().
2. Expand symmetrize() to accept a specified tolerance (in one use case, to avoid an exception raise if atoms aren't mapped successfully with a too-tight tolerance).
3. Provide is_XYZ_symmetric() which checks if given cartesians are symmetric wrt the symmetry operations of the molecule.  This allows a caller to check (and possibly discard) a set of asymmetric coordinates without putting them into the current molecule.

is_symmetric , valid_atom_map, and is_xyz_symmetric do not raise exceptions for asymmetric coordinates.  They return False.  compute_atom_map and symmetrize can raise exceptions (via atom_at_position) if a map fails.

## TODOS
Remaining question is whether there is a more intelligent default/tolerance level for these functions (compute_atom_map(), valid_atom_map(), symmetrize()).  They can be used for many different things.  As far as pyOptking is concerned, they will be specified explicitly.

## Status
Everything in there working wonderfully!
