### PR TITLE
Switch to libxc 5

### DIFF
--- a/external/upstream/libxc/CMakeLists.txt
+++ b/external/upstream/libxc/CMakeLists.txt
@@ -15,10 +15,9 @@ else()
         # Default: use a stable release tarball of libxc. To use the
         # development version of libxc, instead, comment the first URL line,
         # and uncomment the second URL line.
-        #URL http://www.tddft.org/programs/octopus/down.php?file=libxc/4.3.4/libxc-4.3.4.tar.gz
-        #URL https://gitlab.com/libxc/libxc/-/archive/4.3.4/libxc-4.3.4.tar.gz
-        URL https://gitlab.com/libxc/libxc/-/archive/master/libxc-master.tar.gz
-        UPDATE_COMMAND ""
+        URL https://gitlab.com/libxc/libxc/-/archive/5.0.0/libxc-5.0.0.tar.gz
+        #URL https://gitlab.com/libxc/libxc/-/archive/master/libxc-master.tar.gz
+        #UPDATE_COMMAND ""
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${STAGED_INSTALL_PREFIX}
                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}

--- a/psi4/src/psi4/libfunctional/LibXCfunctional.cc
+++ b/psi4/src/psi4/libfunctional/LibXCfunctional.cc
@@ -85,12 +85,11 @@ LibXCFunctional::LibXCFunctional(std::string xc_name, bool unpolarized) {
     }
 
     // Extract variables
-    if (xc_functional_->info->family == XC_FAMILY_HYB_GGA
-        || xc_functional_->info->family == XC_FAMILY_HYB_MGGA
+    if (xc_functional_->info->family == XC_FAMILY_HYB_GGA || xc_functional_->info->family == XC_FAMILY_HYB_MGGA
 #ifdef XC_FAMILY_HYB_LDA
         || xc_functional_->info->family == XC_FAMILY_HYB_LDA
 #endif
-        ) {
+    ) {
         /* Range separation? */
         lrc_ = false;
         if (xc_functional_->info->flags & XC_FLAGS_HYB_CAMY) {
@@ -254,115 +253,45 @@ std::map<std::string, double> LibXCFunctional::query_libxc(const std::string& fu
 void LibXCFunctional::set_tweak(std::vector<double> values) {
     bool failed = true;
     size_t vsize = values.size();
-    if (xc_func_name_ == "XC_GGA_X_B86") {
-        if (vsize == 3) {
-            // (XC(func_type) *p, FLOAT beta, FLOAT gamma, FLOAT omega);
-            // xc_gga_x_b86_set_params(xc_functional_.get(), values[0], values[1], values[2]);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-    } else if (xc_func_name_ == "XC_GGA_X_B88") {
-        if (vsize == 2) {
-            // (XC(func_type) *p, FLOAT beta, FLOAT gamma);
-            // xc_gga_x_b88_set_params(xc_functional_.get(), values[0], values[1]);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-    } else if (xc_func_name_ == "XC_GGA_X_PBE") {
-        if (vsize == 2) {
-            // (XC(func_type) *p, FLOAT kappa, FLOAT mu);
-            // xc_gga_x_pbe_set_params(xc_functional_.get(), values[0], values[1]);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-    } else if (xc_func_name_ == "XC_GGA_C_PBE") {
+    int npars = xc_func_info_get_n_ext_params(xc_functional_.get()->info);
+    if (npars == 0) {
+        throw PSIEXCEPTION(
+            "LibXCfunctional: set_tweak: There are no known tweaks for this functional, please double check "
+            "the functional form and add them if required.");
+    } else if (npars != vsize) {
+        std::ostringstream oss;
+        oss << "got " << vsize << ", expected " << npars;
+        throw PSIEXCEPTION(
+            "LibXCfunctional: set_tweak: Mismatch in size of tweaker vector and expected number of "
+            "input parameters:" +
+            oss.str() + "\n");
+    }
+
+    if (xc_func_name_ == "XC_GGA_C_PBE") {
         if (vsize == 3) {
             // (XC(func_type) *p, FLOAT beta); FLOAT gamma, FLOAT BB
             // xc_gga_c_pbe_set_params(xc_functional_.get(), values[0]);
-            values[1] = xc_func_info_get_ext_params_default_value(const_cast<xc_func_info_type*>(xc_functional_->info), 1);
-            values[2] = xc_func_info_get_ext_params_default_value(const_cast<xc_func_info_type*>(xc_functional_->info), 2);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-    } else if (xc_func_name_ == "XC_GGA_X_MPW91") {
-        if (vsize == 3) {
-            // (XC(func_type) *p, FLOAT a, FLOAT b, FLOAT c, FLOAT d, FLOAT f, FLOAT alpha, FLOAT expo);
-            // xc_gga_x_pw91_set_params(xc_functional_.get(), values[0], values[1], values[2], values[3], values[4],
-            //                          values[5], values[6]);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-    } else if (xc_func_name_ == "XC_GGA_X_RPBE") {
-        if (vsize == 2) {
-            // (XC(func_type) *p, FLOAT kappa, FLOAT mu);
-            // xc_gga_x_rpbe_set_params(xc_functional_.get(), values[0], values[1]);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-    } else if (xc_func_name_ == "XC_GGA_X_OPTX") {
-        if (vsize == 3) {
-            // (XC(func_type) *p, FLOAT a, FLOAT b, FLOAT gamma);
-            // xc_gga_x_optx_set_params(xc_functional_.get(), values[0], values[1], values[2]);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-    } else if (xc_func_name_ == "XC_GGA_C_LYP") {
-        if (vsize == 4) {
-            // (XC(func_type) *p, FLOAT A, FLOAT B, FLOAT c, FLOAT d);
-            // xc_gga_c_lyp_set_params(xc_functional_.get(), values[0], values[1], values[2], values[3]);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-    } else if ((xc_func_name_ == "XC_HYB_GGA_XC_HSE03") || (xc_func_name_ == "XC_HYB_GGA_XC_HSE06")) {
-        if (vsize == 3) {
-            // "Mixing parameter beta", "Screening parameter omega_HF", "Screening parameter omega_PBE"
+            values[1] =
+                xc_func_info_get_ext_params_default_value(const_cast<xc_func_info_type*>(xc_functional_->info), 1);
+            values[2] =
+                xc_func_info_get_ext_params_default_value(const_cast<xc_func_info_type*>(xc_functional_->info), 2);
             xc_func_set_ext_params(xc_functional_.get(), values.data());
             failed = false;
         }
     } else if (xc_func_name_ == "XC_MGGA_X_TPSS") {
         if (vsize == 7) {
             // (xc_func_type *p, double b, double c, double e, double kappa, double mu, double BLOC_a, double BLOC_bu);
-            // xc_mgga_x_tpss_set_params(xc_functional_.get(), values[0], values[1], values[2], values[3], values[4], 2.0,
+            // xc_mgga_x_tpss_set_params(xc_functional_.get(), values[0], values[1], values[2], values[3],
+            // values[4], 2.0,
             //                           0.0);
             values[5] = 2.0;
             values[6] = 0.0;
             xc_func_set_ext_params(xc_functional_.get(), values.data());
             failed = false;
         }
-    } else if (xc_func_name_ == "XC_MGGA_C_TPSS") {
-        if (vsize == 6) {
-            // (xc_func_type *p, double beta, double d, double C0_0, double C0_1, double C0_2, double C0_3);
-            // xc_mgga_c_tpss_set_params(xc_functional_.get(), values[0], values[1], values[2], values[3], values[4],
-            //                           values[5]);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-    } else if (xc_func_name_ == "XC_MGGA_C_BC95") {
-        if (vsize == 2) {
-            // (XC(func_type) *p, FLOAT css, FLOAT copp);
-            // xc_mgga_c_bc95_set_params(xc_functional_.get(), values[0], values[1]);
-            xc_func_set_ext_params(xc_functional_.get(), values.data());
-            failed = false;
-        }
-        // } else if (xc_func_name_ == "XC_MGGA_C_PKZB") {
-        //     if (vsize == 6) {
-        //         // ((XC(func_type) *p, FLOAT beta, FLOAT d, FLOAT C0_0, FLOAT C0_1, FLOAT C0_2, FLOAT
-        //         // C0_3);
-        //         xc_mgga_c_pkzb_set_params(xc_functional_.get(), values[0], values[1], values[2], values[3],
-        //                                   values[4], values[5]);
-        //         failed = false;
-        //     }
     } else {
-        throw PSIEXCEPTION(
-            "LibXCfunctional: set_tweak: There are no known tweaks for this functional, please double check "
-            "the functional form and add them if required.");
-    }
-
-    // Did we match fully?
-    if (failed) {
-        throw PSIEXCEPTION(
-            "LibXCfunctional: set_tweak: Mismatch in size of tweaker vector and expected number of "
-            "input parameters.");
+        xc_func_set_ext_params(xc_functional_.get(), values.data());
+        failed = false;
     }
 
     user_tweakers_ = values;
@@ -786,10 +715,10 @@ void LibXCFunctional::compute_functional(const std::map<std::string, SharedVecto
                 }
             }
         }
-        if (deriv > 2) { // lgtm[cpp/constant-comparison]
+        if (deriv > 2) {  // lgtm[cpp/constant-comparison]
             throw PSIEXCEPTION("TRYING TO COMPUTE DERIV > 3 ");
         }
     }  // End polarized
 }
 
-}  // End namespace
+}  // namespace psi


### PR DESCRIPTION
## Description
Switches to libxc 5 stable, adds consistency checks and default tweaker.

## Todos
Notable points (developer or user-interest) that this PR has or will accomplish.
- [ ] Feature1
- [ ] Feature2

## Questions
- [ ] Question1

## Checklist
- [ ] Tests added for any new features
- [ ] [All or relevant fraction of full tests run](http://psicode.org/psi4manual/master/build_planning.html#how-to-run-a-subset-of-tests)

## Status
- [x] Ready for review
- [x] Ready for merge
